### PR TITLE
可搜索地点里添加废弃前进基地的正则表达式

### DIFF
--- a/规则配置/规则/可搜索地点-key.yaml
+++ b/规则配置/规则/可搜索地点-key.yaml
@@ -16,3 +16,5 @@ match_rules:
       - '^AsteroidBase_P\d+_L\d+$'
       # 焰联-行政机库匹配规则
       - 'ExecutiveHangar_P\d+_L\d+$'
+      # 斯坦顿废弃前进基地
+      - '^FOB_Abandoned_Stanton.*?_FOB\d{1,}(,P){0,1}$'


### PR DESCRIPTION
如题，`规则配置/规则/可搜索地点-key.yaml`里添加了新的一行正则表达式：  
`^FOB_Abandoned_Stanton.*?_FOB\d{1,}(,P){0,1}$`  
用来匹配斯坦顿的一些废弃前进基地（例：天涯）  
影响范围：  
```
FOB_Abandoned_Stanton1_FOB1=实信镇
FOB_Abandoned_Stanton1_FOB2=三曲镇
FOB_Abandoned_Stanton1_FOB3=里科遗迹
FOB_Abandoned_Stanton1_FOB4=破碎之地
FOB_Abandoned_Stanton1a_FOB1=残邑
FOB_Abandoned_Stanton1a_FOB2=烟囱站
FOB_Abandoned_Stanton1a_FOB3=女巫结社
FOB_Abandoned_Stanton1b_FOB1=烂尾站
FOB_Abandoned_Stanton1b_FOB2=僻园
FOB_Abandoned_Stanton1c_FOB1=无谓镇
FOB_Abandoned_Stanton1c_FOB2=狂乱营地
FOB_Abandoned_Stanton1d_FOB1=坑蒙庄
FOB_Abandoned_Stanton1d_FOB2=荫蔽处
FOB_Abandoned_Stanton2a_FOB1=狭地镇
FOB_Abandoned_Stanton2a_FOB2=密谋地
FOB_Abandoned_Stanton2a_FOB3=空谷
FOB_Abandoned_Stanton2a_FOB4=结核地
FOB_Abandoned_Stanton2b_FOB1=明洛塔
FOB_Abandoned_Stanton2b_FOB2,P=泣岩
FOB_Abandoned_Stanton2b_FOB3,P=善终之所
FOB_Abandoned_Stanton2c_FOB1=半丘
FOB_Abandoned_Stanton2c_FOB2=罗洛陨坑
FOB_Abandoned_Stanton2c_FOB3=主线
FOB_Abandoned_Stanton3a_FOB1=石头滩
FOB_Abandoned_Stanton3a_FOB2=天涯
FOB_Abandoned_Stanton3a_FOB3=秘事所
FOB_Abandoned_Stanton3a_FOB4=弥留处
FOB_Abandoned_Stanton3a_FOB5=燃烬地
FOB_Abandoned_Stanton3a_FOB6=巴尔托盲点
FOB_Abandoned_Stanton3b_FOB1=阿克弯
FOB_Abandoned_Stanton3b_FOB2=沉舟处
FOB_Abandoned_Stanton3b_FOB3=败涂地
FOB_Abandoned_Stanton3b_FOB4=威利平原
FOB_Abandoned_Stanton4_FOB1=科洛谷底
FOB_Abandoned_Stanton4_FOB2=流民营地
FOB_Abandoned_Stanton4_FOB3=海拉遗地
FOB_Abandoned_Stanton4_FOB4=荒原
FOB_Abandoned_Stanton4a_FOB1=鄙坡
FOB_Abandoned_Stanton4a_FOB2=哈斯宾厅
FOB_Abandoned_Stanton4a_FOB3=军团陵
FOB_Abandoned_Stanton4a_FOB4=铁拳擂台
FOB_Abandoned_Stanton4b_FOB1=康德峰
FOB_Abandoned_Stanton4b_FOB2=特雷蒙特
FOB_Abandoned_Stanton4c_FOB1=奇袭地
FOB_Abandoned_Stanton4c_FOB2=阿黛尔幽居
```